### PR TITLE
Handle paginated response when retrieving transaction from Tangerine

### DIFF
--- a/lib/plugins/TangerineBankingPlugin.js
+++ b/lib/plugins/TangerineBankingPlugin.js
@@ -231,8 +231,22 @@ class TangerineBankingPlugin extends BasePlugin {
       },
     });
 
+    let transactions = [];
+
+    // Handle paginated response
+    while (tResult.transactions.length > 0) {
+      transactions.push(...tResult.transactions);
+      const nextURI = 'https://secure.tangerine.ca/web/rest' + tResult.links[0].href;
+
+      this.logger.debug(`Retrieving next page from ${nextURI}`);
+
+      tResult = await this.tangerineGetRequest({
+        uri: nextURI,
+      });
+    }
+
     // Parse the individual transaction entries in the result
-    return this.parseTransactionRows(tResult.transactions);
+    return this.parseTransactionRows(transactions);
   }
 
   // istanbul ignore next


### PR DESCRIPTION
Current implementation only fetches the first page. This fix makes it follow the links returned in the response, thereby returning all transactions requested.